### PR TITLE
Support more than one line per code.

### DIFF
--- a/med/medmarkdown.py
+++ b/med/medmarkdown.py
@@ -24,6 +24,7 @@ class MedProcessor(Preprocessor):
     def run(self, lines):
         last_outer = ''
         outputs = []
+        last_outer = None
 
         for line in lines:
             m = self.LINE_REG.match(line)
@@ -39,10 +40,13 @@ class MedProcessor(Preprocessor):
                 else:
                     prefix = '##'
 
-                outputs.append('{} {} \n{}\n\n'.format(prefix, CODES.get(title), notes))
+                outputs.append('{} {} \n{}'.format(prefix, CODES.get(title), notes))
                 if not spaces:
                     last_outer = title
             else:
+                if last_outer and line.strip():
+                    self.structured[last_outer]['notes'] += " " + line.strip()
+                last_outer = None
                 outputs.append(line)
 
         return outputs

--- a/test_data/less_simple.txt
+++ b/test_data/less_simple.txt
@@ -1,0 +1,6 @@
+
+PC/ Mobility issues across multiple lines until
+we find a newline
+
+HPC/ None
+

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -4,9 +4,18 @@ from med.medmarkdown import MedExtension
 
 def test_simple():
     m = MedExtension()
-    html = markdown.markdown("""
+    markdown.markdown("""
         OBS/Observation
     """, extensions=[m])
 
     s = m.get_structured_data()
     assert s['OBS']['notes'] == 'Observation', s
+
+def test_less_simple():
+    contents = open('test_data/less_simple.txt', 'r').read()
+    m = MedExtension()
+    html = markdown.markdown(contents, extensions=[m])
+    s = m.get_structured_data()
+    assert s['PC']['notes'] == 'Mobility issues across multiple lines until we find a newline', s
+    print html
+


### PR DESCRIPTION
After typing a code, the text for the notes is used until a blankline
is encountered.

```
PR/This is a long line
across more than one line

More text..
```

Will set

```
{'PR': {'notes': 'This is a long line across more than one line'}}
```