### PR TITLE
Fix parsing of multiline indented tags

### DIFF
--- a/med/medmarkdown.py
+++ b/med/medmarkdown.py
@@ -46,7 +46,8 @@ class MedProcessor(Preprocessor):
             else:
                 if last_outer and line.strip():
                     self.structured[last_outer]['notes'] += " " + line.strip()
-                last_outer = None
+                if line.strip():
+                    last_outer = None
                 outputs.append(line)
 
         return outputs

--- a/test_data/less_simple.txt
+++ b/test_data/less_simple.txt
@@ -4,3 +4,8 @@ we find a newline
 
 HPC/ None
 
+    RES/ None
+
+    CAR/ None
+
+


### PR DESCRIPTION
When we find a blank line and stop processing a tag, make sure that we remember the tag until we get to a non-tag content block.