### PR TITLE
Adding Open Knowledge Format bundle

### DIFF
--- a/.okf/crate/cli-medmd.md
+++ b/.okf/crate/cli-medmd.md
@@ -1,0 +1,38 @@
+---
+type: CLI Tool
+title: medmd CLI
+description: Command-line tool reading Medical Markdown from a file or stdin and emitting HTML, structured JSON, or both, with custom-code support.
+resource: https://github.com/folkengine/medical-markdown/blob/master/src/bin/medmd.rs
+tags: [rust, cli]
+timestamp: '2026-07-28T01:15:00Z'
+---
+
+# Usage
+
+```bash
+s/dev examples/consultation.md          # HTML + JSON (default: both)
+s/dev examples/consultation.md --json   # structured JSON only
+s/dev examples/consultation.md --html   # HTML only
+echo "PC/ chest pain" | s/dev -         # read from stdin
+s/dev input.txt --codes custom-codes.json --json
+```
+
+`s/dev` runs `medmd` via `cargo run` in development; `s/build` produces an
+optimised binary at `target/release/medmd` (see
+[dev scripts](/tooling/dev-scripts.md)).
+
+# Behaviour
+
+- Input: first positional argument that isn't a flag; `-` or no argument
+  reads stdin.
+- `--json` / `--html` select one output; with neither flag, both are
+  printed (HTML first).
+- `--codes <path.json>` loads custom codes and merges them over the
+  built-in set via the [code registry](/crate/code-registry.md) — a custom
+  code with a built-in abbreviation takes precedence.
+- Errors (unreadable input, bad codes file) print to stderr and exit 1.
+
+# Citations
+
+[1] [src/bin/medmd.rs](https://github.com/folkengine/medical-markdown/blob/master/src/bin/medmd.rs)
+[2] [examples/consultation.md](https://github.com/folkengine/medical-markdown/blob/master/examples/consultation.md)

--- a/.okf/crate/code-registry.md
+++ b/.okf/crate/code-registry.md
@@ -1,0 +1,48 @@
+---
+type: Component
+title: Clinical code registry
+description: The built-in vocabulary of 34 clinical codes in five categories, and the runtime CodeRegistry for loading and merging custom codes from JSON.
+resource: https://github.com/folkengine/medical-markdown/blob/master/src/registry.rs
+tags: [rust, codes, vocabulary, registry]
+timestamp: '2026-07-28T01:15:00Z'
+---
+
+# Built-in vocabulary
+
+`src/codes.rs` defines `CLINICAL_CODES`: 34 static codes mapping shorthand
+to full AoMRC/PRSB clinical headings (e.g. `PC` → "Presenting Complaint",
+`PMH` → "Past Medical History"). Each code has a `CodeCategory`:
+
+| Category | Examples |
+|----------|----------|
+| `History` | `PC`, `HPC`, `PMH`, `DH`, `FH` |
+| `Examination` | `OE`, `RS`, `CVS` |
+| `Vitals` | `PR`, `BP`, `RR` |
+| `Assessment` | `IMP`, `PLAN` |
+| `Other` | `TODO` |
+
+# Runtime registry
+
+`CodeRegistry` (in `src/registry.rs`) wraps the vocabulary in a `HashMap`
+for O(1) lookup and implements `MarkdownItExt`, so the
+[parser plugin](/crate/parser-plugin.md) reads it from parser state.
+
+Constructors, in order of preference for embedding:
+
+- `CodeRegistry::default()` — the 34 built-in codes.
+- `CodeRegistry::from_json_str(&str)` — primary loader for embedding
+  consumers holding config in memory (added for GitEHR — see
+  [requirements](/spec/gitehr-embedding.md)).
+- `CodeRegistry::from_reader(r)` — any `Read` source.
+- `CodeRegistry::from_json(path)` — thin file-path wrapper.
+
+`merge(&other)` overlays another registry; **a custom code with the same
+abbreviation as a built-in one wins**. The JSON format is an array of
+`{ "code", "heading", "category" }` objects, as used by the
+[CLI's](/crate/cli-medmd.md) `--codes` flag.
+
+# Citations
+
+[1] [src/codes.rs](https://github.com/folkengine/medical-markdown/blob/master/src/codes.rs)
+[2] [src/registry.rs](https://github.com/folkengine/medical-markdown/blob/master/src/registry.rs)
+[3] [README — custom codes](https://github.com/folkengine/medical-markdown/blob/master/README.md)

--- a/.okf/crate/index.md
+++ b/.okf/crate/index.md
@@ -1,0 +1,8 @@
+# Rust crate
+
+* [Library API (embedding entry points)](library-api.md) - One-call entry points — parse, parse_with_registry, has_codes — and the ParsedDocument handle for structured data, HTML, and AST access.
+* [markdown-it parser plugin](parser-plugin.md) - The block-level markdown-it rule that parses CODE/ lines into MedicalSection, MedicalSubSection, and MedicalNotes AST nodes and renders semantic HTML.
+* [Clinical code registry](code-registry.md) - The built-in vocabulary of 34 clinical codes in five categories, and the runtime CodeRegistry for loading and merging custom codes from JSON.
+* [Structured extraction output contract](output-schema.md) - The two extraction shapes — the typed, versioned MedicalDocument (schema_version 1) to persist, and the flat JSON map for wire/MCP use.
+* [medmd CLI](cli-medmd.md) - Command-line tool reading Medical Markdown from a file or stdin and emitting HTML, structured JSON, or both, with custom-code support.
+* [WASM bindings crate](wasm-bindings.md) - The medical-markdown-wasm workspace crate exposing parse_to_html, parse_to_json, and a combined parse to JavaScript via wasm-bindgen.

--- a/.okf/crate/library-api.md
+++ b/.okf/crate/library-api.md
@@ -1,0 +1,59 @@
+---
+type: API Surface
+title: Library API (embedding entry points)
+description: One-call entry points — parse, parse_with_registry, has_codes — and the ParsedDocument handle for structured data, HTML, and AST access.
+resource: https://github.com/folkengine/medical-markdown/blob/master/src/api.rs
+tags: [rust, api, embedding]
+timestamp: '2026-07-28T01:15:00Z'
+---
+
+# Purpose
+
+The `src/api.rs` module wraps the `MarkdownIt` setup boilerplate so a
+backend consumer (such as GitEHR — see
+[GitEHR embedding requirements](/spec/gitehr-embedding.md)) goes straight
+from a Markdown body to structured data or HTML.
+
+# Examples
+
+```rust
+let doc = medical_markdown::parse(body);
+
+if doc.has_codes() {
+    let document = doc.document();  // typed MedicalDocument: versioned, spans
+    let data = doc.structured();    // flat serde_json::Value for MCP/wire use
+    let html = doc.html();          // semantic HTML for display surfaces
+}
+```
+
+With a custom in-memory vocabulary (reuse the registry across calls):
+
+```rust
+let registry = medical_markdown::CodeRegistry::from_json_str(codes_json)?;
+let doc = medical_markdown::parse_with_registry(body, &registry);
+```
+
+# Surface
+
+| Item | Role |
+|------|------|
+| `parse(body) -> ParsedDocument` | Parse with the built-in vocabulary |
+| `parse_with_registry(body, &registry)` | Parse with a custom [code registry](/crate/code-registry.md) |
+| `has_codes(body) -> bool` | Cheap pre-check, no full parse; most plain-prose bodies answer `false` quickly |
+| `ParsedDocument::document()` | Typed, versioned `MedicalDocument` — the shape to persist ([contract](/crate/output-schema.md)) |
+| `ParsedDocument::structured()` | Flat `serde_json::Value` projection for wire/MCP |
+| `ParsedDocument::html()` | Semantic HTML rendering |
+| `ParsedDocument::ast()` | Borrow the underlying `markdown_it::Node` AST |
+
+Lower-level pieces stay public for consumers that want direct control:
+`add` / `add_with_registry` register the [parser plugin](/crate/parser-plugin.md)
+on a `MarkdownIt` instance, and `extract_document` / `extract_structured_data`
+walk an AST.
+
+Plain-prose bodies with no clinical codes always extract to an empty
+structure and never error.
+
+# Citations
+
+[1] [src/api.rs](https://github.com/folkengine/medical-markdown/blob/master/src/api.rs)
+[2] [src/lib.rs exports](https://github.com/folkengine/medical-markdown/blob/master/src/lib.rs)

--- a/.okf/crate/output-schema.md
+++ b/.okf/crate/output-schema.md
@@ -1,0 +1,68 @@
+---
+type: Data Contract
+title: Structured extraction output contract
+description: The two extraction shapes — the typed, versioned MedicalDocument (schema_version 1) to persist, and the flat JSON map for wire/MCP use.
+resource: https://github.com/folkengine/medical-markdown/blob/master/docs/output-schema.md
+tags: [rust, schema, contract, extraction, gitehr]
+timestamp: '2026-07-28T01:15:00Z'
+---
+
+# Two shapes, one parse
+
+| Shape | Produced by | Consumer | Versioned |
+|-------|-------------|----------|-----------|
+| Typed `MedicalDocument` | `extract_document(&ast)` / `ParsedDocument::document()` | Rust consumers that persist and diff (GitEHR) — **the shape to persist** | Yes — `SCHEMA_VERSION` = 1 |
+| Flat map (`serde_json::Value`) | `extract_structured_data(&ast)` / `ParsedDocument::structured()` | MCP/wire convenience projection | No |
+
+Both preserve document order (`serde_json` `preserve_order`) and both
+extract plain prose to an empty result without erroring.
+
+# Typed document (`MedicalDocument`)
+
+```json
+{
+  "schema_version": 1,
+  "sections": [
+    { "code": "OE", "heading": "On Examination", "notes": "Alert",
+      "subsections": [
+        { "code": "RS", "heading": "Respiratory System", "notes": "Clear",
+          "source": { "start_line": 3, "end_line": 3 } }
+      ],
+      "source": { "start_line": 2, "end_line": 3 } }
+  ]
+}
+```
+
+- `notes` are whitespace-normalised (newlines and whitespace runs collapse
+  to single spaces).
+- `subsections` is omitted from serialisation when empty.
+- `source` spans are **inclusive 1-based line ranges**; a section's span
+  covers its notes and all sub-sections. Line numbers were chosen over byte
+  offsets because they are robust to CRLF/LF and tab normalisation;
+  byte-offset spans are deferred to a future schema version.
+- Bump `SCHEMA_VERSION` only when consumers must migrate.
+
+# Flat map
+
+```json
+{
+  "PC": { "notes": "Headache" },
+  "OE": { "notes": "Alert", "RS": "Clear" },
+  "_source_map": { "PC": 1, "OE": 2, "OE.RS": 3 }
+}
+```
+
+Keyed by section code; sub-sections appear as string entries inside their
+parent. `_source_map` maps `CODE` and `CODE.SUBCODE` keys to 1-based start
+lines and is omitted entirely when there are no sections. This shape is
+unversioned — treat it as a projection of the typed document.
+
+The contract exists because GitEHR diffs persisted structure across time —
+see [GitEHR embedding requirements](/spec/gitehr-embedding.md). Behaviour
+is pinned by the [conformance suite](/spec/conformance-suite.md); the types
+live in [the crate's model module](/crate/library-api.md).
+
+# Citations
+
+[1] [docs/output-schema.md](https://github.com/folkengine/medical-markdown/blob/master/docs/output-schema.md)
+[2] [src/model.rs](https://github.com/folkengine/medical-markdown/blob/master/src/model.rs)

--- a/.okf/crate/parser-plugin.md
+++ b/.okf/crate/parser-plugin.md
@@ -1,0 +1,49 @@
+---
+type: Component
+title: markdown-it parser plugin
+description: The block-level markdown-it rule that parses CODE/ lines into MedicalSection, MedicalSubSection, and MedicalNotes AST nodes and renders semantic HTML.
+resource: https://github.com/folkengine/medical-markdown/blob/master/src/plugin.rs
+tags: [rust, parser, markdown-it, html]
+timestamp: '2026-07-28T01:15:00Z'
+---
+
+# Architecture
+
+Medical Markdown is implemented as a **plugin on the `markdown-it` crate**,
+not a vendored or forked parser. `add(md)` (or `add_with_registry`)
+registers a block rule alongside the standard CommonMark rules, so inline
+Markdown (bold, links, …) inside notes keeps working for free. This
+plugin-not-fork architecture is a deliberate keeper — GitEHR depends on it
+(see [non-requirements](/spec/gitehr-embedding.md)).
+
+# AST node types
+
+| Node | Meaning | Carries |
+|------|---------|---------|
+| `MedicalSection` | Top-level `PC/ …` line | `code`, `heading`, `source_line`, `end_line` |
+| `MedicalSubSection` | Indented `RS/ …` under a section | `code`, `heading`, `source_line`, `end_line` |
+| `MedicalNotes` | Free text within a section | `text` |
+
+Line numbers are 1-based and inclusive; a section's `end_line` covers its
+own notes and all sub-sections. These feed the spans in the
+[structured output contract](/crate/output-schema.md).
+
+# Rendering
+
+- Section → `<section class="med-section med-{code}" data-med-code="CODE">`
+  with an `<h2>` heading.
+- Sub-section → `<section class="med-subsection med-{code}">` with `<h3>`.
+
+The `data-med-code` attribute and `med-*` CSS classes are the hooks display
+surfaces style against.
+
+Headings come from the [code registry](/crate/code-registry.md); an
+unrecognised code renders with the code itself as heading. The syntax rules
+the plugin implements are specified in
+[the language spec](/spec/language.md) and pinned by the
+[conformance suite](/spec/conformance-suite.md).
+
+# Citations
+
+[1] [src/plugin.rs](https://github.com/folkengine/medical-markdown/blob/master/src/plugin.rs)
+[2] [markdown-it crate](https://crates.io/crates/markdown-it)

--- a/.okf/crate/wasm-bindings.md
+++ b/.okf/crate/wasm-bindings.md
@@ -1,0 +1,44 @@
+---
+type: Component
+title: WASM bindings crate
+description: The medical-markdown-wasm workspace crate exposing parse_to_html, parse_to_json, and a combined parse to JavaScript via wasm-bindgen.
+resource: https://github.com/folkengine/medical-markdown/tree/master/medical-markdown-wasm
+tags: [wasm, browser, bindings]
+timestamp: '2026-07-28T01:15:00Z'
+---
+
+# Purpose
+
+`medical-markdown-wasm/` is a separate workspace crate (`cdylib` + `rlib`)
+that compiles the Rust parser to WebAssembly so the
+[interactive demo](/tooling/demo-deployment.md) runs the *same* parser in
+the browser that backends embed natively.
+
+# Surface
+
+Three `#[wasm_bindgen]` functions, each building a fresh parser with the
+default [code registry](/crate/code-registry.md):
+
+| Function | Returns |
+|----------|---------|
+| `parse_to_html(input)` | Rendered HTML string |
+| `parse_to_json(input)` | Pretty-printed structured JSON (flat shape) |
+| `parse(input)` | JSON object `{ "html": "...", "structured": {...} }` |
+
+The structured output is the flat map from the
+[output contract](/crate/output-schema.md).
+
+# Building
+
+```bash
+cargo install wasm-pack    # one-time
+s/build-wasm               # builds to pkg/
+```
+
+CI builds it on every push ([CI pipeline](/tooling/ci-pipeline.md)), and
+the Pages workflow rebuilds it for deployment.
+
+# Citations
+
+[1] [medical-markdown-wasm/src/lib.rs](https://github.com/folkengine/medical-markdown/blob/master/medical-markdown-wasm/src/lib.rs)
+[2] [medical-markdown-wasm/Cargo.toml](https://github.com/folkengine/medical-markdown/blob/master/medical-markdown-wasm/Cargo.toml)

--- a/.okf/decisions/index.md
+++ b/.okf/decisions/index.md
@@ -1,0 +1,4 @@
+# Decisions
+
+* [Rust is the canonical implementation](rust-canonical.md) - The Rust crate is the single authoritative implementation; the original Python package was removed after its behaviour was captured as conformance fixtures.
+* [MIT licence, diverging from the AGPL house default](mit-license.md) - The repository is MIT-licensed as a deliberate divergence from the house-style AGPL-3.0-or-later default, to keep the format and parser embeddable.

--- a/.okf/decisions/mit-license.md
+++ b/.okf/decisions/mit-license.md
@@ -1,0 +1,26 @@
+---
+type: Decision
+title: MIT licence, diverging from the AGPL house default
+description: The repository is MIT-licensed as a deliberate divergence from the house-style AGPL-3.0-or-later default, to keep the format and parser embeddable.
+tags: [decision, licence]
+timestamp: '2026-07-28T01:15:00Z'
+---
+
+# Decision
+
+This repository is licensed under **MIT**, a deliberate divergence from
+the house-style default of AGPL-3.0-or-later.
+
+# Rationale
+
+Medical Markdown is intended as a permissive, embeddable format and
+reference parser. MIT lowers the barrier to adoption in both open source
+and proprietary EPR systems. Concretely: GitEHR is itself AGPL-3.0 and can
+depend on this crate without licence friction — recorded as a
+non-requirement to preserve in the
+[GitEHR embedding requirements](/spec/gitehr-embedding.md).
+
+# Citations
+
+[1] [README — License](https://github.com/folkengine/medical-markdown/blob/master/README.md)
+[2] [LICENSE](https://github.com/folkengine/medical-markdown/blob/master/LICENSE)

--- a/.okf/decisions/rust-canonical.md
+++ b/.okf/decisions/rust-canonical.md
@@ -1,0 +1,38 @@
+---
+type: Decision
+title: Rust is the canonical implementation
+description: The Rust crate is the single authoritative implementation; the original Python package was removed after its behaviour was captured as conformance fixtures.
+tags: [decision, rust, python, conformance]
+timestamp: '2026-07-28T01:15:00Z'
+---
+
+# Decision
+
+The Rust crate in this repository is the **single canonical
+implementation** of Medical Markdown. The original Python package has been
+removed.
+
+# Rationale and mechanism
+
+Rather than keeping two implementations in sync, the Python behaviour was
+captured as language-agnostic fixtures in the
+[gold-standard conformance suite](/spec/conformance-suite.md), which pins
+behaviour **as data**: a behaviour is part of the spec when there is a
+fixture for it. This made deleting the Python tree safe — the spec no
+longer lives in any implementation's code.
+
+Consequences:
+
+- New behaviour is specified by adding a fixture *first*; the
+  implementation is correct when it reproduces every fixture.
+- Future implementations in other languages conform by reproducing the
+  same fixtures, not by porting Rust code.
+- The crate is built as a plugin on `markdown-it`
+  ([parser plugin](/crate/parser-plugin.md)) rather than a vendored parser,
+  which the first consumer explicitly wants preserved
+  ([GitEHR requirements](/spec/gitehr-embedding.md)).
+
+# Citations
+
+[1] [ROADMAP — Direction](https://github.com/folkengine/medical-markdown/blob/master/ROADMAP.md)
+[2] [README — Canonical implementation](https://github.com/folkengine/medical-markdown/blob/master/README.md)

--- a/.okf/getting-started.md
+++ b/.okf/getting-started.md
@@ -1,0 +1,43 @@
+---
+type: Guide
+title: Getting started with the Medical Markdown knowledge bundle
+description: Orientation for the Medical Markdown project and a map of this knowledge bundle.
+tags: [getting-started, overview]
+timestamp: '2026-07-28T01:15:00Z'
+---
+
+# What this project is
+
+Medical Markdown is a Markdown-like specification for writing free-text
+clinical notes that parse into structured data, using Academy of Medical
+Royal Colleges / PRSB document headings. A clinician writes shorthand such
+as `PC/ chest pain` and the parser produces both semantic HTML and
+structured JSON keyed by clinical code.
+
+The repository holds the **single canonical implementation**: a Rust crate
+built as a `markdown-it` plugin (see
+[Rust is the canonical implementation](/decisions/rust-canonical.md)),
+plus a WASM build for the browser demo and a CLI (`medmd`).
+
+# Where to start
+
+- The language itself: [Medical Markdown language](/spec/language.md)
+- What "correct" means: [conformance suite](/spec/conformance-suite.md)
+- Embedding the crate as a library: [library API](/crate/library-api.md)
+  and the [structured output contract](/crate/output-schema.md)
+- Why the work is shaped this way:
+  [GitEHR embedding requirements](/spec/gitehr-embedding.md)
+
+# Bundle map
+
+- `/spec/` — the language, its gold-standard fixtures, and consumer-driven
+  requirements.
+- `/crate/` — the Rust crate's surfaces: API, parser plugin, code registry,
+  output contract, CLI, WASM bindings.
+- `/decisions/` — recorded decisions and their rationale.
+- `/tooling/` — dev scripts, CI, and demo deployment.
+
+# Citations
+
+[1] [README](https://github.com/folkengine/medical-markdown/blob/master/README.md)
+[2] [ROADMAP](https://github.com/folkengine/medical-markdown/blob/master/ROADMAP.md)

--- a/.okf/index.md
+++ b/.okf/index.md
@@ -1,0 +1,23 @@
+---
+okf_version: '0.1'
+---
+
+# Medical Markdown Knowledge Bundle
+
+* [Getting started](getting-started.md) - orientation for the Medical Markdown project and a map of this bundle.
+
+# Specification
+
+* [Specification](spec/) - the Medical Markdown language, its gold-standard conformance fixtures, and the GitEHR embedding requirements driving the roadmap.
+
+# Rust crate
+
+* [Rust crate](crate/) - the canonical implementation's surfaces: library API, parser plugin, code registry, output contract, CLI, and WASM bindings.
+
+# Decisions
+
+* [Decisions](decisions/) - recorded decisions with rationale: Rust as canonical implementation, MIT licence divergence.
+
+# Tooling
+
+* [Tooling](tooling/) - dev scripts, CI pipeline, and the GitHub Pages demo deployment.

--- a/.okf/log.md
+++ b/.okf/log.md
@@ -1,0 +1,7 @@
+# Update Log
+
+## 2026-07-28
+* **Creation**: Populated the bundle from the codebase: [language spec](/spec/language.md), [conformance suite](/spec/conformance-suite.md), [GitEHR embedding requirements](/spec/gitehr-embedding.md), [library API](/crate/library-api.md), [parser plugin](/crate/parser-plugin.md), [code registry](/crate/code-registry.md), [output contract](/crate/output-schema.md), [medmd CLI](/crate/cli-medmd.md), [WASM bindings](/crate/wasm-bindings.md), [dev scripts](/tooling/dev-scripts.md), [CI pipeline](/tooling/ci-pipeline.md), [demo deployment](/tooling/demo-deployment.md).
+* **Creation**: Recorded decisions: [Rust is the canonical implementation](/decisions/rust-canonical.md) and [MIT licence divergence](/decisions/mit-license.md).
+* **Update**: Rewrote [getting started](/getting-started.md) as a project orientation and bundle map; added per-directory indexes and expanded the root [index](/index.md).
+* **Creation**: Scaffolded the Medical Markdown Knowledge Bundle bundle with `okf_init.py` — see [getting started](getting-started.md).

--- a/.okf/spec/conformance-suite.md
+++ b/.okf/spec/conformance-suite.md
@@ -1,0 +1,61 @@
+---
+type: Test Suite
+title: Gold-standard conformance suite
+description: Language-agnostic fixtures in tests/conformance/ that define the extraction contract; a behaviour is in the spec when a fixture exists for it.
+resource: https://github.com/folkengine/medical-markdown/tree/master/tests/conformance
+tags: [spec, testing, conformance, gold-standard]
+timestamp: '2026-07-28T01:15:00Z'
+---
+
+# Role
+
+`tests/conformance/` is the **gold standard** for Medical Markdown. It
+defines the extraction contract as data, independent of any implementation.
+The rule: *a behaviour is "in the spec" when there is a fixture for it.*
+New language features (e.g. `RX/`, SNOMED annotation) get a fixture first;
+an implementation is correct when it reproduces every fixture.
+
+The suite preserves the behaviour of the original Python implementation,
+which allowed the Python tree to be deleted — see
+[Rust is the canonical implementation](/decisions/rust-canonical.md).
+
+# Layout
+
+Each case is a pair in `cases/` sharing a base name:
+
+- `cases/<name>.md` — input Markdown body
+- `cases/<name>.json` — exact output `extract_structured_data` must produce
+  with the built-in vocabulary, including `_source_map` where sections exist
+
+Comparison is by JSON value, so key ordering is not asserted here (ordering
+has dedicated tests in `tests/integration.rs`).
+
+# Current cases
+
+| Case | Behaviour pinned |
+|------|------------------|
+| `single-code` | One `CODE/` line extracts to one section |
+| `multiline-notes` | Continuation lines append to the current section |
+| `subsections` | Indented codes nest under their parent section |
+| `blank-lines-between` | A blank line ends the current section |
+| `empty-document` | Empty input → empty structure |
+| `empty-notes` | A code with no notes still yields a section |
+| `plain-prose` | Non-medical prose → empty structure, no error |
+| `lowercase-not-parsed` | Lowercase `pc/` is not a code |
+| `unknown-code-passthrough` | Unrecognised codes preserved verbatim |
+| `full-consultation` | End-to-end realistic consultation |
+
+# Running and extending
+
+```sh
+cargo test --test conformance
+```
+
+The Rust harness (`tests/conformance.rs`) discovers every `cases/*.md`,
+parses with the default registry, and asserts equality against the sibling
+`.json`. To add a behaviour: write the `.md` and `.json` pair, keep it small
+and focused on one behaviour, and run the harness.
+
+# Citations
+
+[1] [Conformance suite README](https://github.com/folkengine/medical-markdown/blob/master/tests/conformance/README.md)

--- a/.okf/spec/gitehr-embedding.md
+++ b/.okf/spec/gitehr-embedding.md
@@ -1,0 +1,70 @@
+---
+type: Requirements
+title: GitEHR embedding requirements
+description: Requirements from embedding the crate into GitEHR, the first real consumer, grouped in four priorities with current status.
+tags: [gitehr, embedding, requirements, roadmap]
+timestamp: '2026-07-28T01:15:00Z'
+---
+
+# Context
+
+[GitEHR](https://github.com/gitehr) is the first real consumer of the
+crate. It stores each clinical encounter as YAML front matter plus a
+free-text Markdown body; the body is canonical and structured data is
+extracted *on demand*, never stored separately. So the crate is used as a
+pure backend function — body in, structure out — with HTML needed only for
+display surfaces. Many bodies contain no `CODE/` lines at all.
+
+# Priorities and status
+
+## Priority 1 — library ergonomics (done)
+
+- ✅ One-call entry points: `parse(body)` → `ParsedDocument`, plus
+  `parse_with_registry` — see [library API](/crate/library-api.md).
+- ✅ `has_codes(body)` cheap pre-check without a full parse.
+- ✅ Registry loading from memory: `CodeRegistry::from_json_str` /
+  `from_reader` — see [code registry](/crate/code-registry.md).
+- ⬜ Feature-gate rendering vs extraction (`render` Cargo feature). Note:
+  `markdown-it` is needed for extraction too, so this mainly gates the
+  rendering convenience surface.
+
+## Priority 2 — stable, typed, versioned output contract (done)
+
+GitEHR persists derived structure into State files and diffs it across
+time, so the output shape is a contract — see
+[structured output contract](/crate/output-schema.md).
+
+- ✅ Typed `MedicalDocument` with `schema_version` alongside the flat JSON.
+- ✅ Schema documented in `docs/output-schema.md`.
+- ✅ Full inclusive line spans per section and sub-section.
+- ⬜ Byte-offset spans (deferred; line spans are robust to normalisation).
+
+## Priority 3 — validation and diagnostics (open)
+
+- ⬜ `validate(body, &registry) -> Vec<Diagnostic>` advisory pass
+  ("line 5: unrecognised code `XYZ/`") without making extraction fallible.
+
+## Priority 4 — clinical syntax for State projection (open, highest value)
+
+GitEHR's payoff feature promotes extracted items into longitudinal State
+files (problem list, medication list). Blocked specifically on the first
+two:
+
+- ⬜ `RX/` medication syntax (`RX/ amoxicillin 500mg TDS 7/7` → drug, dose,
+  frequency, duration) feeding `state/medications.md`.
+- ⬜ SNOMED-CT inline annotation (`IMP/ #73211009 diabetes mellitus`)
+  feeding `state/problems.md` and FHIR/openEHR export.
+- ⬜ Vital signs with units (`BP/ 120/80 mmHg`) as typed measurements.
+
+# Non-requirements (already right, keep them)
+
+- Ordering preserved via `serde_json` `preserve_order` — GitEHR relies on it.
+- Plain prose extracts cleanly to empty; must never error.
+- Plugin-on-`markdown-it` architecture (no vendoring) is what GitEHR wants.
+- The [MIT licence](/decisions/mit-license.md) lets AGPL-3.0 GitEHR depend
+  on the crate without friction.
+
+# Citations
+
+[1] [spec.md — embedding requirements](https://github.com/folkengine/medical-markdown/blob/master/spec.md)
+[2] [ROADMAP.md — GitEHR sections](https://github.com/folkengine/medical-markdown/blob/master/ROADMAP.md)

--- a/.okf/spec/index.md
+++ b/.okf/spec/index.md
@@ -1,0 +1,5 @@
+# Specification
+
+* [Medical Markdown language](language.md) - The CODE/ shorthand syntax for clinical sections, its parsing rules, and the basic vs extended specification split.
+* [Gold-standard conformance suite](conformance-suite.md) - Language-agnostic fixtures in tests/conformance/ that define the extraction contract; a behaviour is in the spec when a fixture exists for it.
+* [GitEHR embedding requirements](gitehr-embedding.md) - Requirements from embedding the crate into GitEHR, the first real consumer, grouped in four priorities with current status.

--- a/.okf/spec/language.md
+++ b/.okf/spec/language.md
@@ -1,0 +1,61 @@
+---
+type: Specification
+title: Medical Markdown language
+description: The CODE/ shorthand syntax for clinical sections, its parsing rules, and the basic vs extended specification split.
+tags: [spec, syntax, parsing]
+timestamp: '2026-07-28T01:15:00Z'
+---
+
+# Syntax
+
+Medical Markdown is standard (Daring Fireball–style) Markdown plus `CODE/`
+prefixes that denote clinical sections:
+
+```text
+PC/ chest pain, worse on exertion
+HPC/ Patient reports 2-hour history of central chest pain.
+Pain radiates to left arm.
+OE/ Alert and oriented
+    RS/ Clear bilaterally
+    CVS/ Heart sounds normal, no murmurs
+IMP/ Possible ACS
+PLAN/ ECG, troponin, aspirin 300mg
+```
+
+# Parsing rules
+
+- Top-level `CODE/` lines become `<section>` + `<h2>` elements.
+- Indented `CODE/` lines become nested sub-sections (`<section>` + `<h3>`),
+  e.g. `RS/` under `OE/`.
+- Continuation lines (no code prefix) append to the current section's notes.
+- A blank line ends the current section.
+- Codes are uppercase; lowercase `pc/` is not parsed as a code
+  (pinned by the `lowercase-not-parsed` conformance fixture).
+- Unrecognised codes pass through: the code is preserved verbatim and its
+  heading falls back to the code itself (`unknown-code-passthrough` fixture).
+- Plain prose with no codes always extracts to an empty structure and never
+  errors — non-medical input is a first-class case.
+
+Recognised codes and their full clinical headings come from the
+[code registry](/crate/code-registry.md); every rule above is pinned as data
+in the [conformance suite](/spec/conformance-suite.md).
+
+# Basic vs extended specification
+
+- **Basic** — asynchronous parsing only: text is written, saved, and parsed
+  later, with no real-time interaction. This is what the Rust crate
+  implements.
+- **Extended** — adds synchronous, real-time features such as terminology
+  pick lists fed by a REST terminology server, constrained by document
+  section, the clinician's usage history, or local guidance. Not yet
+  implemented; tracked on the roadmap.
+
+Planned syntax growth (see [GitEHR requirements](/spec/gitehr-embedding.md)):
+`RX/` structured medication lines, inline SNOMED-CT annotation
+(`IMP/ #73211009 diabetes mellitus`), and vital signs with units.
+
+# Citations
+
+[1] [README — basic and extended specification](https://github.com/folkengine/medical-markdown/blob/master/README.md)
+[2] [Crate rustdoc syntax summary](https://github.com/folkengine/medical-markdown/blob/master/src/lib.rs)
+[3] [Project wiki](https://github.com/open-health-hub/medical-markdown/wiki)

--- a/.okf/tooling/ci-pipeline.md
+++ b/.okf/tooling/ci-pipeline.md
@@ -1,0 +1,33 @@
+---
+type: CI Pipeline
+title: CI pipeline
+description: GitHub Actions workflow running lint/test/build, the WASM build, and zizmor workflow-security checks, with all actions SHA-pinned.
+resource: https://github.com/folkengine/medical-markdown/blob/master/.github/workflows/ci.yml
+tags: [ci, github-actions, security]
+timestamp: '2026-07-28T01:15:00Z'
+---
+
+# Jobs
+
+`ci.yml` runs on pushes to `master`, pull requests, and manual dispatch,
+with per-ref concurrency cancellation and read-only `contents` permission.
+
+| Job | What it does |
+|-----|--------------|
+| Test & Lint | `s/lint` (clippy + rustfmt), `s/test`, `s/build` via the [dev scripts](/tooling/dev-scripts.md) |
+| WASM Build | `s/build-wasm` with `wasm-pack` installed via `taiki-e/install-action` (pinned `wasm-pack@0.15.0`) |
+| GitHub Actions security | `zizmor --strict-collection .` (pinned `zizmor@1.27.0`) audits the workflows themselves |
+
+# House style
+
+- Every action is **pinned by commit SHA** with a matching `# vX.Y.Z`
+  comment (e.g. `actions/checkout@9c091bb… # v7.0.0`).
+- `persist-credentials: false` on every checkout.
+- `dtolnay/rust-toolchain` requires an explicit `toolchain: stable` input.
+- The [demo deployment](/tooling/demo-deployment.md) is a separate
+  workflow, not a CI job.
+
+# Citations
+
+[1] [.github/workflows/ci.yml](https://github.com/folkengine/medical-markdown/blob/master/.github/workflows/ci.yml)
+[2] [zizmor](https://github.com/zizmorcore/zizmor)

--- a/.okf/tooling/demo-deployment.md
+++ b/.okf/tooling/demo-deployment.md
@@ -1,0 +1,42 @@
+---
+type: Deployment
+title: Interactive demo and GitHub Pages deployment
+description: The demo.html page served locally by s/demo and deployed to GitHub Pages by demo.yml, running the Rust parser compiled to WASM.
+resource: https://github.com/folkengine/medical-markdown/blob/master/.github/workflows/demo.yml
+tags: [demo, github-pages, wasm, deployment]
+timestamp: '2026-07-28T01:15:00Z'
+---
+
+# What ships
+
+A single static `demo.html` that loads the Rust parser compiled to WASM
+from `pkg/` (the [WASM bindings crate](/crate/wasm-bindings.md)). The live
+deployment is at <https://pacharanero.github.io/medical-markdown/>.
+
+# Pages workflow (`demo.yml`)
+
+- Triggers on pushes to `master` that touch `demo.html`, the WASM crate,
+  the Rust parser (`src/**`, `Cargo.toml`, `Cargo.lock`), or the workflow
+  itself; also manual dispatch.
+- Each run rebuilds the WASM from source (`s/build-wasm`), assembles a
+  minimal `demo-dist/` (just `demo.html` + `pkg/` + a generated root
+  `index.html` that redirects to `demo.html`), and hands it to Pages as a
+  **workflow artifact — there is no `gh-pages` branch**.
+- One-off repo prerequisite: Settings → Pages → Source must be
+  "GitHub Actions"; if left at "Deploy from a branch", `deploy-pages`
+  fails with "Get Pages site failed".
+- Actions are SHA-pinned per the same house style as the
+  [CI pipeline](/tooling/ci-pipeline.md).
+
+# Local development
+
+`s/demo` serves the repository on the first free port in 8000–8030 and
+opens the demo (pass a port to override, e.g. `s/demo 9000`). If
+`s/build-wasm` has been run, the demo uses the Rust parser via WASM;
+otherwise it **falls back to a built-in JS parser** inside `demo.html`.
+
+# Citations
+
+[1] [.github/workflows/demo.yml](https://github.com/folkengine/medical-markdown/blob/master/.github/workflows/demo.yml)
+[2] [demo.html](https://github.com/folkengine/medical-markdown/blob/master/demo.html)
+[3] [README — Interactive demo](https://github.com/folkengine/medical-markdown/blob/master/README.md)

--- a/.okf/tooling/dev-scripts.md
+++ b/.okf/tooling/dev-scripts.md
@@ -1,0 +1,27 @@
+---
+type: Dev Tooling
+title: Development scripts (s/)
+description: The s/ directory of thin wrapper scripts that standardise install, dev-run, test, lint, build, WASM build, and demo serving.
+resource: https://github.com/folkengine/medical-markdown/tree/master/s
+tags: [tooling, scripts, workflow]
+timestamp: '2026-07-28T01:15:00Z'
+---
+
+# Scripts
+
+All routine tasks go through the `s/` directory ("scripts-to-rule-them-all"
+style); CI runs the same scripts, so local and CI behaviour match.
+
+| Script | Purpose |
+|--------|---------|
+| `s/install` | Install dependencies and build the project |
+| `s/dev` | Run the [`medmd` CLI](/crate/cli-medmd.md) in development mode |
+| `s/test` | Run the test suite (`cargo test`), including the [conformance suite](/spec/conformance-suite.md) |
+| `s/lint` | Run clippy and check formatting |
+| `s/build` | Optimised release binary at `target/release/medmd` |
+| `s/build-wasm` | Build the [WASM package](/crate/wasm-bindings.md) to `pkg/` (requires `wasm-pack`) |
+| `s/demo` | Serve the [interactive demo](/tooling/demo-deployment.md) on the first free port in 8000–8030 (pass a port to override) |
+
+# Citations
+
+[1] [README — All scripts](https://github.com/folkengine/medical-markdown/blob/master/README.md)

--- a/.okf/tooling/index.md
+++ b/.okf/tooling/index.md
@@ -1,0 +1,5 @@
+# Tooling
+
+* [Development scripts (s/)](dev-scripts.md) - The s/ directory of thin wrapper scripts that standardise install, dev-run, test, lint, build, WASM build, and demo serving.
+* [CI pipeline](ci-pipeline.md) - GitHub Actions workflow running lint/test/build, the WASM build, and zizmor workflow-security checks, with all actions SHA-pinned.
+* [Interactive demo and GitHub Pages deployment](demo-deployment.md) - The demo.html page served locally by s/demo and deployed to GitHub Pages by demo.yml, running the Rust parser compiled to WASM.


### PR DESCRIPTION
The PR uses the [Open Knowledge Format](https://github.com/catancs/okf-skill) skill in Claude Code to create an okf bundle for the project. 

Caught your [video on YouTube](https://www.youtube.com/watch?v=bgVkNkyH7E8). Love this idea!